### PR TITLE
Add ColorSchemeScript to layout.tsx to address dark mode flash on site

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={inter.className}>
-      <ColorSchemeScript defaultColorScheme="light" />
+        <ColorSchemeScript defaultColorScheme="light" />
         <MantineProvider defaultColorScheme="light">
           <AppShell
             header={{ height: "96px" }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { Inter } from "next/font/google";
 import "@mantine/core/styles.layer.css";
-import { MantineProvider, AppShell } from "@mantine/core";
+import { ColorSchemeScript, MantineProvider, AppShell } from "@mantine/core";
 import Navbar from "@/components/Navbar/Navbar";
 import SideNavMenu from "@/components/Navbar/SideNavMenu";
 import Footer from "@/components/Footer/Footer";
@@ -22,7 +22,8 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={inter.className}>
-        <MantineProvider>
+      <ColorSchemeScript defaultColorScheme="light" />
+        <MantineProvider defaultColorScheme="light">
           <AppShell
             header={{ height: "96px" }}
             footer={{ height: "283px" }} // adjust based on footer height


### PR DESCRIPTION
## Current functionality
On page reload, if dark mode is enabled on browser, there is a flash of an attempt to render in dark mode

## Fix
On page reload, color is consistent and no longer tried to match browser mode due to dark mode not having supported designs